### PR TITLE
Add built-in cron feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ You can try to run in dry-run mode first to see what is going to be purged:
 
     docker exec -t registry-ui /opt/docker-registry-ui -purge-tags -dry-run
 
+Alternatively, you can schedule the purging task with built-in cron service.
+
+```config.yaml
+purge_tags_keep_days: 90
+purge_tags_keep_count: 2
+purge_tags_schedule: '10 3 * * *'
+```
+
 ### Debug mode
 
 To increase http request verbosity, run container with `-e GOREQUEST_DEBUG=1`.

--- a/config.yml
+++ b/config.yml
@@ -38,7 +38,9 @@ admins: []
 # Debug mode. Affects only templates.
 debug: true
 
-# CLI options.
 # How many days to keep tags but also keep the minimal count provided no matter how old.
 purge_tags_keep_days: 90
 purge_tags_keep_count: 2
+# Schedules to purge tags with cron format. (Only for server mode)
+# Empty string disables this feature.
+purge_tags_schedule: ''

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d156899e94e2d0d92ed200d5729bec5d0d205b5b98bbf2bd89f7f91c9ed7a518
-updated: 2018-05-28T13:28:11.313447+03:00
+hash: fea96c473a02b07acc1d600ee0f71c6a5143f34e5eb04a4c5e3e14378fca46f0
+updated: 2018-06-09T09:03:51.972089+09:00
 imports:
 - name: github.com/CloudyKit/fastprinter
   version: 74b38d55f37af5d6c05ca11147d616b613a3420e
@@ -36,6 +36,8 @@ imports:
   version: a578a48e8d6ca8b01a3b18314c43c6716bb5f5a3
 - name: github.com/pkg/errors
   version: 816c9085562cd7ee03e7f8188a1cfd942858cded
+- name: github.com/robfig/cron
+  version: b41be1df696709bb6395fe435af20370037c0b4c
 - name: github.com/tidwall/gjson
   version: 01f00f129617a6fe98941fb920d6c760241b54d2
 - name: github.com/tidwall/match

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,6 +14,8 @@ import:
 - package: github.com/mattn/go-sqlite3
   version: 1.7.0
 - package: github.com/go-sql-driver/mysql
+- package: github.com/robfig/cron
+  version: ~1.1.0
 testImport:
 - package: github.com/smartystreets/goconvey
   version: 1.6.2


### PR DESCRIPTION
I have added built-in cron feature.
With this PR, Unix crond is no longer required.

To use this feature, you must specify a new config parameter `purge_tags_schedule`.

```diff
purge_tags_keep_days: 90
purge_tags_keep_count: 2
+purge_tags_schedule: '10 3 * * *'
```

By the way, I feel we need the refactoring of `main.go`.
It has a lot of responsibilities.