### PR TITLE
Allow the timezone to be set via the host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ ENV GOPATH /opt
 ENV GO111MODULE on
 
 RUN apk update && \
-    apk add ca-certificates git bash gcc musl-dev
+    apk add ca-certificates git bash gcc musl-dev && \
+    apk add tzdata
 
 WORKDIR /opt/src/github.com/quiq/docker-registry-ui
 ADD events events
@@ -24,8 +25,6 @@ RUN apk add --no-cache ca-certificates && \
 ADD templates /opt/templates
 ADD static /opt/static
 COPY --from=builder /opt/docker-registry-ui /opt/
-
-RUN apk update && apk add tzdata
 
 USER nobody
 ENTRYPOINT ["/opt/docker-registry-ui"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,7 @@ ADD templates /opt/templates
 ADD static /opt/static
 COPY --from=builder /opt/docker-registry-ui /opt/
 
+RUN apk update && apk add tzdata
+
 USER nobody
 ENTRYPOINT ["/opt/docker-registry-ui"]


### PR DESCRIPTION
Adjusted the Dockerfile so that the package tzdata is installed. This should allow anyone to use the -e flag when running a container in order to specify the timezone.
See:
- [Setting the timezone in Alpine Linux](https://wiki.alpinelinux.org/wiki/Setting_the_timezone)
- [Docker Container time & timezone](https://serverfault.com/a/683651/496454)
