### PR TITLE
Support V2 Manifest Lists

### DIFF
--- a/main.go
+++ b/main.go
@@ -264,7 +264,7 @@ func (a *apiClient) viewTagInfo(c echo.Context) error {
 	data.Set("repo", repo)
 	data.Set("sha256", sha256)
 	data.Set("imageSize", imageSize)
-	data.Set("tag", gjson.Get(infoV1, "tag").String())
+	data.Set("tag", tag)
 	data.Set("repoPath", gjson.Get(infoV1, "name").String())
 	data.Set("created", gjson.Get(gjson.Get(infoV1, "history.0.v1Compatibility").String(), "created").String())
 	data.Set("layersCount", layersCount)

--- a/templates/tag_info.html
+++ b/templates/tag_info.html
@@ -17,11 +17,10 @@
             <th colspan="2">Image Details</th>
         </tr>
     </thead>
-    {{if not isDigest}}
     <tr>
         <td width="20%">Image</td><td>{{ registryHost }}/{{ repoPath }}:{{ tag }}</td>
     </tr>
-    {{end}}
+    {{if not isListOnly}}
     <tr>
         <td>sha256</td><td>{{ sha256 }}</td>
     </tr>
@@ -36,32 +35,44 @@
     <tr>
         <td>Layer Count</td><td>{{ layersCount }}</td>
     </tr>
+    {{end}}
 </table>
 
-{{if len(digests) != 0}}
+{{if digests}}
 <h4>Manifest List v2</h4>
+{{range index, manifest := digests}}
 <table class="table table-striped table-bordered">
     <thead bgcolor="#ddd">
         <tr>
-            <th>Manifest #</th>
-            <th>Digest</th>
-            <th>Size</th>
-            <th>Architecture</th>
-            <th>OS</th>
+            <th colspan="2">Manifest #{{ index+1 }}</th>
         </tr>
     </thead>
-{{range index, manifest := digests}}
+    {{range key := manifest["ordered_keys"]}}
     <tr>
-        <td>{{ index+1 }}</td>
+        <td width="20%">{{ key }}</td>
+        {{if key == "platform" || key == "annotations"}}
+        <td style="padding: 0">
+            <table class="table table-bordered" style="padding: 0; width: 100%; margin-bottom: 0; min-height: 37px">
+                <!-- Nested range does not work. Iterating via filter over the map. -->
+                {{ manifest[key]|parse_map|raw }}
+            </table>
+        </td>
+        {{else if key == "size"}}
+        <td>{{ manifest[key]|pretty_size }}</td>
+        {{else if key == "digest"}}
+        {{if not isListOnly}}
         <td><a href='{{ basePath }}/{{ namespace }}/{{ repo }}/{{ manifest["digest"] }}'>{{ manifest["digest"] }}</a></td>
-        <td>{{ digestSizes[index]|pretty_size }}</td>
-        <td>{{ manifest["architecture"] }}</td>
-        <td>{{ manifest["os"] }}</td>
+        {{else}}
+        <td>{{ manifest["digest"] }}</td>
+        {{end}}
+        {{else}}
+        <td>{{ manifest[key] }}</td>
+        {{end}}
     </tr>
-{{end}}
+    {{end}}
 </table>
-{{else}}
-{{if layersV2}}
+{{end}}
+{{else if layersV2}}
 <h4>Manifest v2</h4>
 <table class="table table-striped table-bordered">
     <thead bgcolor="#ddd">
@@ -80,9 +91,8 @@
 {{end}}
 </table>
 {{end}}
-{{end}}
 
-{{if not isDigest}}
+{{if not isListOnly && not isDigest}}
 <h4>Manifest v1</h4>
 {{range index, layer := layersV1}}
 <table class="table table-striped table-bordered">

--- a/templates/tag_info.html
+++ b/templates/tag_info.html
@@ -17,15 +17,19 @@
             <th colspan="2">Image Details</th>
         </tr>
     </thead>
+    {{if not isDigest}}
     <tr>
         <td width="20%">Image</td><td>{{ registryHost }}/{{ repoPath }}:{{ tag }}</td>
     </tr>
+    {{end}}
     <tr>
         <td>sha256</td><td>{{ sha256 }}</td>
     </tr>
+    {{if not isDigest}}
     <tr>
         <td>Created On</td><td>{{ created|pretty_time }}</td>
     </tr>
+    {{end}}
     <tr>
         <td>Image Size</td><td>{{ imageSize|pretty_size }}</td>
     </tr>
@@ -34,6 +38,29 @@
     </tr>
 </table>
 
+{{if len(digests) != 0}}
+<h4>Manifest List v2</h4>
+<table class="table table-striped table-bordered">
+    <thead bgcolor="#ddd">
+        <tr>
+            <th>Manifest #</th>
+            <th>Digest</th>
+            <th>Size</th>
+            <th>Architecture</th>
+            <th>OS</th>
+        </tr>
+    </thead>
+{{range index, manifest := digests}}
+    <tr>
+        <td>{{ index+1 }}</td>
+        <td><a href='{{ basePath }}/{{ namespace }}/{{ repo }}/{{ manifest["digest"] }}'>{{ manifest["digest"] }}</a></td>
+        <td>{{ digestSizes[index]|pretty_size }}</td>
+        <td>{{ manifest["architecture"] }}</td>
+        <td>{{ manifest["os"] }}</td>
+    </tr>
+{{end}}
+</table>
+{{else}}
 {{if layersV2}}
 <h4>Manifest v2</h4>
 <table class="table table-striped table-bordered">
@@ -53,7 +80,9 @@
 {{end}}
 </table>
 {{end}}
+{{end}}
 
+{{if not isDigest}}
 <h4>Manifest v1</h4>
 {{range index, layer := layersV1}}
 <table class="table table-striped table-bordered">
@@ -80,6 +109,7 @@
     </tr>
     {{end}}
 </table>
+{{end}}
 {{end}}
 
 {{end}}


### PR DESCRIPTION
I implemented support for v2 manifest lists (https://docs.docker.com/engine/reference/commandline/manifest/).
This enables the proper display of multi-arch images, such as those generated by Docker BuildX or manually.

Tag view for multi-arch image:
![manifestlists](https://user-images.githubusercontent.com/6362238/74593409-48000c80-502b-11ea-8668-ea92b46e4621.PNG)

Detail view of sub-image:
![detail](https://user-images.githubusercontent.com/6362238/74593416-551cfb80-502b-11ea-9139-97a2f20adaff.PNG)


