### PR TITLE
Add limit when calling v1/_catalog

### DIFF
--- a/registry/client.go
+++ b/registry/client.go
@@ -178,7 +178,7 @@ func (c *Client) Repositories(useCache bool) map[string][]string {
 
 	linkRegexp := regexp.MustCompile("^<(.*?)>;.*$")
 	scope := "registry:catalog:*"
-	uri := "/v2/_catalog"
+	uri := "/v2/_catalog?n=1000"
 	c.repos = map[string][]string{}
 	for {
 		data, resp := c.callRegistry(uri, scope, "manifest.v2")


### PR DESCRIPTION
n value is based on AWS ECR (Member must have value less than or equal to 1000)