### PR TITLE
Keep tags based on regex

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -50,6 +50,8 @@ debug: true
 # How many days to keep tags but also keep the minimal count provided no matter how old.
 purge_tags_keep_days: 90
 purge_tags_keep_count: 2
+# Keep tags matching regexp no matter how old
+# purge_tags_keep_regexp: '^latest$'
 # Enable built-in cron to schedule purging tags in server mode.
 # Empty string disables this feature.
 # Example: '25 54 17 * * *' will run it at 17:54:25 daily.

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ type configData struct {
 	Debug                 bool     `yaml:"debug"`
 	PurgeTagsKeepDays     int      `yaml:"purge_tags_keep_days"`
 	PurgeTagsKeepCount    int      `yaml:"purge_tags_keep_count"`
+	PurgeTagsKeepRegexp   string   `yaml:"purge_tags_keep_regexp"`
 	PurgeTagsSchedule     string   `yaml:"purge_tags_schedule"`
 }
 
@@ -351,5 +352,5 @@ func (a *apiClient) receiveEvents(c echo.Context) error {
 
 // purgeOldTags purges old tags.
 func (a *apiClient) purgeOldTags(dryRun bool) {
-	registry.PurgeOldTags(a.client, dryRun, a.config.PurgeTagsKeepDays, a.config.PurgeTagsKeepCount)
+	registry.PurgeOldTags(a.client, dryRun, a.config.PurgeTagsKeepDays, a.config.PurgeTagsKeepCount, a.config.PurgeTagsKeepRegexp)
 }

--- a/registry/tasks.go
+++ b/registry/tasks.go
@@ -88,8 +88,7 @@ func PurgeOldTags(client *Client, purgeDryRun bool, purgeTagsKeepDays, purgeTags
 		for _, tag := range repos[repo] {
 			regexpKeep := false
 			if purgeTagsKeepRegexp != "" {
-				regexpMatch, _ := regexp.MatchString(purgeTagsKeepRegexp, tag.name)
-				regexpKeep = regexpMatch
+				regexpKeep, _ = regexp.MatchString(purgeTagsKeepRegexp, tag.name)
 			}
 			delta := int(now.Sub(tag.created).Hours() / 24)
 			if !regexpKeep && delta > purgeTagsKeepDays {

--- a/registry/tasks.go
+++ b/registry/tasks.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"time"
 
@@ -32,7 +33,7 @@ func (p timeSlice) Swap(i, j int) {
 }
 
 // PurgeOldTags purge old tags.
-func PurgeOldTags(client *Client, purgeDryRun bool, purgeTagsKeepDays, purgeTagsKeepCount int) {
+func PurgeOldTags(client *Client, purgeDryRun bool, purgeTagsKeepDays, purgeTagsKeepCount int, purgeTagsKeepRegexp string) {
 	logger := SetupLogging("registry.tasks.PurgeOldTags")
 	dryRunText := ""
 	if purgeDryRun {
@@ -83,10 +84,11 @@ func PurgeOldTags(client *Client, purgeDryRun bool, purgeTagsKeepDays, purgeTags
 		sort.Sort(sortedTags)
 		repos[repo] = sortedTags
 
-		// Filter out tags by retention days.
+		// Filter out tags by retention days and regexp
 		for _, tag := range repos[repo] {
+			regexpMatch, _ := regexp.MatchString(purgeTagsKeepRegexp, tag.name)
 			delta := int(now.Sub(tag.created).Hours() / 24)
-			if delta > purgeTagsKeepDays {
+			if !regexpMatch && delta > purgeTagsKeepDays {
 				purgeTags[repo] = append(purgeTags[repo], tag.name)
 			} else {
 				keepTags[repo] = append(keepTags[repo], tag.name)

--- a/registry/tasks.go
+++ b/registry/tasks.go
@@ -86,11 +86,11 @@ func PurgeOldTags(client *Client, purgeDryRun bool, purgeTagsKeepDays, purgeTags
 
 		// Filter out tags by retention days and regexp
 		for _, tag := range repos[repo] {
-      regexpKeep := false
-      if purgeTagsKeepRegexp != "" {
-        regexpMatch, _ := regexp.MatchString(purgeTagsKeepRegexp, tag.name)
-        regexpKeep = regexpMatch
-      }
+			regexpKeep := false
+			if purgeTagsKeepRegexp != "" {
+				regexpMatch, _ := regexp.MatchString(purgeTagsKeepRegexp, tag.name)
+				regexpKeep = regexpMatch
+			}
 			delta := int(now.Sub(tag.created).Hours() / 24)
 			if !regexpKeep && delta > purgeTagsKeepDays {
 				purgeTags[repo] = append(purgeTags[repo], tag.name)

--- a/registry/tasks.go
+++ b/registry/tasks.go
@@ -86,9 +86,13 @@ func PurgeOldTags(client *Client, purgeDryRun bool, purgeTagsKeepDays, purgeTags
 
 		// Filter out tags by retention days and regexp
 		for _, tag := range repos[repo] {
-			regexpMatch, _ := regexp.MatchString(purgeTagsKeepRegexp, tag.name)
+      regexpKeep := false
+      if purgeTagsKeepRegexp != "" {
+        regexpMatch, _ := regexp.MatchString(purgeTagsKeepRegexp, tag.name)
+        regexpKeep = regexpMatch
+      }
 			delta := int(now.Sub(tag.created).Hours() / 24)
-			if !regexpMatch && delta > purgeTagsKeepDays {
+			if !regexpKeep && delta > purgeTagsKeepDays {
 				purgeTags[repo] = append(purgeTags[repo], tag.name)
 			} else {
 				keepTags[repo] = append(keepTags[repo], tag.name)


### PR DESCRIPTION
Adds a config option that takes a regex. Tags matching this regex will not be purged.