### PR TITLE
reverse sort tags on name if equal dates

### DIFF
--- a/registry/tasks.go
+++ b/registry/tasks.go
@@ -25,7 +25,11 @@ func (p timeSlice) Len() int {
 }
 
 func (p timeSlice) Less(i, j int) bool {
-	return p[i].created.After(p[j].created)
+	if p[i].created.Equal(p[j].created) {
+		return p[i].name > p[j].name
+	} else {
+		return p[i].created.After(p[j].created)
+	}
 }
 
 func (p timeSlice) Swap(i, j int) {


### PR DESCRIPTION
container images in OCI format don't have a timestamp on when they were created. This means that, when purging, the list of tags all get the same default date, and they will just be sorted alphabetically on name. Since tags are often some kind of versions, it might make sense to sort them in reverse alphabetical order.