### PR TITLE
feat: allow ui customization of items per page

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -92,3 +92,8 @@ purge_tags:
 debug:
   # Affects only templates.
   templates: false
+
+# Ui Options
+ui:
+  # change the default number of item per page (-1 mean all item)
+  default_page_size: 10

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -6,11 +6,32 @@
 <script type="text/javascript" src="{{ basePath }}/static/js/sorting_natural.js"></script>
 <script type="text/javascript">
     $(document).ready(function() {
+        var repoItemPerPage = {{ repoItemPerPage }};
+        var lengthMenu = [10, 25, 50, 100];
+
+        if (!lengthMenu.includes(repoItemPerPage)) {
+            lengthMenu.push(repoItemPerPage);
+        }
+        var sortedLengthMenu = lengthMenu.toSorted((a, b) => {
+            // If 'a' is -1 and 'b' is NOT -1, move 'a' to the end
+            if (a === -1 && b !== -1) return 1;
+
+            // If 'b' is -1 and 'a' is NOT -1, move 'b' to the end
+            if (b === -1 && a !== -1) return -1;
+
+            // For everything else, use normal ascending order
+            return a - b;
+        });
+
         var reposTable = $('#datatable_repos').DataTable({
-            "pageLength": 10,
+            "pageLength": repoItemPerPage,
+            "lengthMenu": sortedLengthMenu,
             "stateSave": true,
             "dom": "<'row'<'col-sm-12'tr>><'row'<'col-sm-4'i><'col-sm-4 text-center'p><'col-sm-4 text-end'l>>",
             "language": {
+                "lengthLabels": {
+                    '-1': 'Show all'
+                },
                 "emptyTable": "Catalog is being initializing...",
                 "info": "Showing _START_ to _END_ of _TOTAL_",
                 "infoFiltered": " (filtered from _MAX_)",
@@ -20,7 +41,8 @@
 
         var areTagsReady = {{ areTagsReady }};
         var tagsTable = $('#datatable_tags').DataTable({
-            "pageLength": 10,
+            "pageLength": repoItemPerPage,
+            "lengthMenu": sortedLengthMenu,
             "order": [[ 0, 'desc' ]],
             "stateSave": true,
             "dom": "<'row'<'col-sm-12'tr>><'row'<'col-sm-4'i><'col-sm-4 text-center'p><'col-sm-4 text-end'l>>",
@@ -28,6 +50,9 @@
               { type: 'natural', targets: 0 }
             ],
             "language": {
+                "lengthLabels": {
+                    '-1': 'Show all'
+                },
                 "emptyTable": areTagsReady ? "No tags." : "Tags are being loaded in the background...",
                 "info": "Showing _START_ to _END_ of _TOTAL_",
                 "infoFiltered": " (filtered from _MAX_)",

--- a/templates/event_log.html
+++ b/templates/event_log.html
@@ -4,8 +4,26 @@
 {{block head()}}
 <script type="text/javascript">
     $(document).ready(function() {
+        var repoItemPerPage = {{ repoItemPerPage }};
+        var lengthMenu = [10, 25, 50, 100];
+
+        if (!lengthMenu.includes(repoItemPerPage)) {
+            lengthMenu.push(repoItemPerPage);
+        }
+        var sortedLengthMenu = lengthMenu.toSorted((a, b) => {
+            // If 'a' is -1 and 'b' is NOT -1, move 'a' to the end
+            if (a === -1 && b !== -1) return 1;
+
+            // If 'b' is -1 and 'a' is NOT -1, move 'b' to the end
+            if (b === -1 && a !== -1) return -1;
+
+            // For everything else, use normal ascending order
+            return a - b;
+        });
+
         var table = $('#datatable').DataTable({
-            "pageLength": 10,
+            "pageLength": repoItemPerPage,
+            "lengthMenu": sortedLengthMenu,
             "order": [[ 4, 'desc' ]],
             "stateSave": false,
             "dom": "<'row'<'col-sm-12'tr>><'row'<'col-sm-4'i><'col-sm-4 text-center'p><'col-sm-4 text-end'l>>",
@@ -14,6 +32,9 @@
                 {search: $('input:checkbox[name="sha256_chk"]').val()},
             ],
             "language": {
+                "lengthLabels": {
+                    '-1': 'Show all'
+                },
                 "emptyTable": "No events.",
                 "info": "Showing _START_ to _END_ of _TOTAL_",
                 "infoFiltered": " (filtered from _MAX_)",

--- a/web.go
+++ b/web.go
@@ -94,6 +94,9 @@ func (a *apiClient) viewCatalog(c echo.Context) error {
 		data.Set("tagsRefreshInfo", tagsRefreshInfo)
 		data.Set("tagCounts", a.client.SubRepoTagCounts(repoPath, repos))
 		data.Set("tags", tags)
+
+		pageSize := viper.GetInt("ui.default_page_size")
+		data.Set("repoItemPerPage", pageSize)
 		if repoPath != "" && (len(repos) > 0 || len(tags) > 0) {
 			// Do not show events in the root of catalog.
 			data.Set("events", a.eventListener.GetEvents(repoPath))
@@ -118,6 +121,8 @@ func (a *apiClient) deleteTag(c echo.Context) error {
 func (a *apiClient) viewEventLog(c echo.Context) error {
 	data := a.setUserPermissions(c)
 	data.Set("events", a.eventListener.GetEvents(""))
+	pageSize := viper.GetInt("ui.default_page_size")
+	data.Set("repoItemPerPage", pageSize)
 	return c.Render(http.StatusOK, "event_log.html", data)
 }
 


### PR DESCRIPTION
This commit introduce a new configuration:

```
ui:
  default_page_size: 10
```

which change the default number of repository in a catalog page